### PR TITLE
Improve example 8.1

### DIFF
--- a/ex8.1/clock/clock.go
+++ b/ex8.1/clock/clock.go
@@ -1,4 +1,16 @@
-// clock is a TCP server that periodically writes the time.
+// Clock creates a concurrent clock server that can accept a port number
+// and can be configured to a time zone through checking the environment
+// variable TZ.  TZ should be set to a region used in the IANA time database
+// accessible for reference here: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+//
+// Three servers that work for the demo are:
+// TZ=America/New_York ./clock_server -port 8000 &
+// TZ=America/Chicago ./clock_server -port 8010 &
+// TZ=America/Los_Angeles ./clock_server -port 8020 &
+//
+// Build Note: the folder is named clock and so is the program, therefore
+// when building use `go build -o clock_server` to create a unique executable.
+
 package main
 
 import (
@@ -7,34 +19,60 @@ import (
 	"io"
 	"log"
 	"net"
+	"os"
 	"time"
 )
 
-var port = flag.Int("port", 8080, "listen port")
-
-func handleConn(c net.Conn) {
-	defer c.Close()
-	for {
-		_, err := io.WriteString(c, time.Now().Format("15:04:05\n"))
-		if err != nil {
-			return // e.g., client disconnected
-		}
-		time.Sleep(1 * time.Second)
-	}
-}
+var port = flag.Int("port", 8000, "localhost port for serving the clock")
 
 func main() {
 	flag.Parse()
-	listener, err := net.Listen("tcp", fmt.Sprintf("localhost:%d", *port))
+	fmt.Println("Port is:", *port)
+	addr := net.JoinHostPort("localhost", fmt.Sprint(*port))
+
+	listener, err := net.Listen("tcp", addr)
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	// Set the timezone.
+	z := setZone()
+
+	log.Println("Clock server listening on:", addr)
 	for {
 		conn, err := listener.Accept()
 		if err != nil {
-			log.Print(err) // e.g., connection aborted
+			log.Print(err) // e.g. Connection aborted
 			continue
 		}
-		go handleConn(conn) // handle connections concurrently
+		go handleConn(conn, z) //handle one connection at a time
+	}
+}
+
+func setZone() *time.Location {
+	//init the loc
+	zone := os.Getenv("TZ")
+	if zone == "" {
+		log.Println("TZ not set, using default: America/Chicago")
+		zone = "America/Chicago"
+	}
+	loc, err := time.LoadLocation(zone)
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Println("Loaded zone:", zone)
+
+	return loc
+}
+
+func handleConn(c net.Conn, z *time.Location) {
+	defer c.Close()
+
+	for {
+		_, err := io.WriteString(c, time.Now().In(z).Format("15:04:05\n"))
+		if err != nil {
+			return //e.g. Client disconnected
+		}
+		time.Sleep(1 * time.Second)
 	}
 }


### PR DESCRIPTION
Let me begin, by saying how much I appreciate you work on this repo.  As an 
experienced programmer coming to Golang I have been blessed by your incredible
dedication and the thoroughness of your solution set.  I wanted to give back a little
by making a few minor improvements here and there.  THANK YOU for this
repo which has made my journey in Go richer and more enjoyable.  This pull
request improves on example 8.1 a little by making the clock server more
configurable and the client more exemplary of the wall of clocks requested in 
the exercise.

This commit improves both the clock server and the clockwall client
from example 8.1.

clock.go is updated to add a feature that reads from an environment
variable 'TZ' to set the time zone of the time server from one
of the defined IANA time database timezone definitions.  This allows
each clock to report in its assigned time zone without configuration
by the client, and is in keeping with the instructions for EX 8.1
which suggests the use of a 'TZ' variable when launching the
clock

clockwall.go is rewritten to implment the in-place updates typically
seen on a wall of clocks.  The original provided concurrent updates
from several clock servers, but the input scrolled down the screen
and did not reflect the use case of a clock wall that visually
tracks times in multiple time zones as typically seen in some hotels,
command and control centers, and data centers with worldwide
customers.  The updated clockwall.go provides continuous feeds from
clock servers on a single line in keeping with the idea of a clock
wall.