### PR TITLE
WIP: ex3.3: add a counter-example showing the wrong solution to the problem

### DIFF
--- a/ex3.3/main.go
+++ b/ex3.3/main.go
@@ -119,5 +119,5 @@ func corner(i, j int) (float64, float64) {
 
 func f(x, y float64) float64 {
 	r := math.Hypot(x, y) // distance from (0,0)
-	return math.Sin(r) / r
+	return 0.1 + math.Sin(r) / r
 }


### PR DESCRIPTION
the entire histogram turned red after little change

![b](https://user-images.githubusercontent.com/1140412/53699064-5d1d6480-3df5-11e9-927b-5ec5eaab62ba.png)
