### PR TITLE
Updated solution to be more fast

### DIFF
--- a/ex8.5/main.go
+++ b/ex8.5/main.go
@@ -29,7 +29,6 @@ func main() {
 	for row := 0; row < height; row++ {
 		rows <- row
 	}
-	close(rows)
 	for i := 0; i < workers; i++ {
 		wg.Add(1)
 		go func() {
@@ -45,7 +44,12 @@ func main() {
 			wg.Done()
 		}()
 	}
-	wg.Wait()
+	// As shown in book page 238 example
+	// This renders image in 100.34 µs where before it took 813 ms.
+	go func(){
+		wg.Wait()
+		close(rows)
+	}
 
 	fmt.Println("rendered in:", time.Since(start))
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
I used special goroutine to close all channels after `wg.Wait()` as shown in book examples. (Page 238).