### PR TITLE
ex8.8: About ticker&timer

### DIFF
--- a/ex8.8/reverb.go
+++ b/ex8.8/reverb.go
@@ -41,19 +41,22 @@ func handleConn(c net.Conn) {
 		c.Close()
 	}()
 	lines := make(chan string)
+	ticker := time.NewTicker(1 * time.Second)
 	go scan(c, lines)
-	timeout := 2 * time.Second
-	timer := time.NewTimer(2 * time.Second)
 	for {
-		select {
-		case line := <-lines:
-			timer.Reset(timeout)
-			wg.Add(1)
-			go echo(c, line, 1*time.Second, wg)
-		case <-timer.C:
-			return
+        for countdown := 10; countdown > 0; countdown-- {
+			select {
+			case line := <-lines:
+                countdown = 10
+				wg.Add(1)
+				go echo(c, line, 1*time.Second, wg)
+			case <-ticker.C:
+			}
 		}
-	}
+		// Timeout
+		ticker.Stop()
+        return
+    }
 }
 
 func main() {


### PR DESCRIPTION
I found that you used `timer` in ex8.8 which was not mentioned in chapter 8.7. So I changed the code to `ticker` version, which contains this usage in article:
```go
ticker := time.NewTicker(1 * time.Second)
<-ticker.C
ticker.Stop()
```
 Also the exercise requires **10s** timeout. I have fixed it too.