### PR TITLE
fix(#38, #40): add a guard for slices with length 0; correct words count in test, reimplement with bufio.ScanWords

### DIFF
--- a/ex4.5/unique.go
+++ b/ex4.5/unique.go
@@ -2,6 +2,10 @@
 package unique
 
 func unique(strs []string) []string {
+	if len(strs) == 0 {
+		return strs
+	}
+
 	w := 0 // index of last written string
 	for _, s := range strs {
 		if strs[w] == s {

--- a/ex4.5/unique_test.go
+++ b/ex4.5/unique_test.go
@@ -6,10 +6,21 @@ import (
 )
 
 func TestUnique(t *testing.T) {
-	s := []string{"a", "a", "b", "c", "c", "c", "d", "d", "e"}
-	got := unique(s)
-	want := []string{"a", "b", "c", "d", "e"}
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("got %v, want %v", got, want)
+	ss := [][]string{
+		{"a", "a", "b", "c", "c", "c", "d", "d", "e"},
+		{},
 	}
+
+	want := [][]string{
+		{"a", "b", "c", "d", "e"},
+		{},
+	}
+
+	for i, s := range ss {
+		got := unique(s)
+		if !reflect.DeepEqual(got, want[i]) {
+			t.Errorf("got %v, want %v", got, want[i])
+		}
+	}
+
 }

--- a/ex7.1/counter_test.go
+++ b/ex7.1/counter_test.go
@@ -24,10 +24,10 @@ func TestLineCounter(t *testing.T) {
 func TestWordCounter(t *testing.T) {
 	c := &WordCounter{}
 	data := [][]byte{
-		[]byte("The upcoming word is sp"),
-		[]byte("lit across the buffer boundary. "),
-		[]byte(" And this one ends on the buffer boundary."),
-		[]byte(" Last words."),
+		[]byte("The upcoming word is sp"),                    // 5
+		[]byte("lit across the buffer boundary. "),           // 5
+		[]byte(" And this one ends on the buffer boundary."), // 8
+		[]byte(" Last words."),                               // 2
 	}
 	for _, p := range data {
 		n, err := c.Write(p)
@@ -36,8 +36,8 @@ func TestWordCounter(t *testing.T) {
 			t.Fail()
 		}
 	}
-	if c.N() != 19 {
-		t.Logf("words: %d != 19", c.N())
+	if c.N() != 20 {
+		t.Logf("words: %d != 20", c.N())
 		t.Fail()
 	}
 }


### PR DESCRIPTION
When the slice's length is 0, should directly return to prevent false
result or slice out of bounds runtime error