### PR TITLE
ex6.3: Fix InterceptWith and DifferenceWith

### DIFF
--- a/ex6.3/intset.go
+++ b/ex6.3/intset.go
@@ -49,9 +49,10 @@ func (s *IntSet) IntersectWith(t *IntSet) {
 	for i, tword := range t.words {
 		if i < len(s.words) {
 			s.words[i] &= tword
-		} else {
-			s.words = append(s.words, tword)
 		}
+	}
+	for i := len(t.words); i < len(s.words); i++ {
+		s.words[i] = 0
 	}
 }
 
@@ -60,8 +61,6 @@ func (s *IntSet) DifferenceWith(t *IntSet) {
 	for i, tword := range t.words {
 		if i < len(s.words) {
 			s.words[i] &^= tword
-		} else {
-			s.words = append(s.words, tword)
 		}
 	}
 }

--- a/ex6.3/intset.go
+++ b/ex6.3/intset.go
@@ -51,8 +51,8 @@ func (s *IntSet) IntersectWith(t *IntSet) {
 			s.words[i] &= tword
 		}
 	}
-	for i := len(t.words); i < len(s.words); i++ {
-		s.words[i] = 0
+	if len(s.words) > len(t.words) {
+		s.words = s.words[:len(t.words)]
 	}
 }
 


### PR DESCRIPTION
- not to append y's element in both methods.
- clear x's element too after len of y.