### PR TITLE
Update conv.go on ex2.2 for flexible input on terminal.

### DIFF
--- a/ex2.2/conv.go
+++ b/ex2.2/conv.go
@@ -1,5 +1,3 @@
-// ex2.2 prints measurements given on the command line or stdin in various
-// units.
 package main
 
 import (
@@ -74,11 +72,20 @@ func newMeasurement(f float64, unit string) (Measurement, error) {
 	case "f":
 		return FromFarenheit(f), nil
 	default:
-		return Distance{}, fmt.Errorf("Unexpected unit %v", unit)
+		return Distance{}, fmt.Errorf("unexpected unit %v", unit)
 	}
 }
 
 func printMeasurement(s string) {
+	f, unit := findMatch(s)
+	m, err := newMeasurement(f, unit)
+	if err != nil {
+		log.Fatalf(err.Error())
+	}
+	fmt.Println(m)
+}
+
+func findMatch(s string) (float64, string) {
 	re := regexp.MustCompile(`(-?\d+(?:\.\d+)?)([A-Za-z]+)`)
 	match := re.FindStringSubmatch(s)
 	if match == nil {
@@ -92,18 +99,15 @@ func printMeasurement(s string) {
 		log.Fatalf("No unit specified.")
 	}
 	unit := match[2]
-	m, err := newMeasurement(f, unit)
-	if err != nil {
-		log.Fatalf(err.Error())
-	}
-	fmt.Println(m)
+	return f, unit
 }
 
 func main() {
+	// $ go run main.go Please convert 12m.
+	// >> 12m = 39.4ft
 	if len(os.Args) > 1 {
-		for _, arg := range os.Args[1:] {
-			printMeasurement(arg)
-		}
+		s := strings.Join(os.Args[1:], " ")
+		printMeasurement(s)
 	} else {
 		scan := bufio.NewScanner(os.Stdin)
 		for scan.Scan() {


### PR DESCRIPTION
kinda prompt engineering approach on ex2.2/conv.go which can be used as an interactive approach on command line argument. now it consider the input and match the regex and convert the unit.